### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ Claude MCP server for Macrostrat API
 
 [![smithery badge](https://smithery.ai/badge/@blake365/macrostrat-mcp)](https://smithery.ai/server/@blake365/macrostrat-mcp)
 
+<a href="https://glama.ai/mcp/servers/v67anfiq0s">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/v67anfiq0s/badge" alt="Macrostrat Server MCP server" />
+</a>
+
 An MCP server implementation for providing access to the [Macrostrat API](https://macrostrat.org/api) within [Claude Desktop](https://claude.ai/download).
 
 ## Overview


### PR DESCRIPTION
This PR adds a badge for the [Macrostrat MCP Server](https://glama.ai/mcp/servers/v67anfiq0s) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/v67anfiq0s">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/v67anfiq0s/badge" alt="Macrostrat Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.